### PR TITLE
Fix  place holder

### DIFF
--- a/ImageHaramBlur/src/main/java/com/ae/imageharamblur/ui/ImageViewFilter.kt
+++ b/ImageHaramBlur/src/main/java/com/ae/imageharamblur/ui/ImageViewFilter.kt
@@ -10,6 +10,7 @@ import android.util.AttributeSet
 import androidx.core.content.withStyledAttributes
 import androidx.core.graphics.drawable.toBitmap
 import coil.Coil
+import coil.request.CachePolicy
 import coil.request.ImageRequest
 import com.ae.imageharamblur.R
 import com.ae.imageharamblur.utils.StackBlur
@@ -35,7 +36,7 @@ class ImageViewFilter @JvmOverloads constructor(
     var imageModel: Any? = null
         set(value) {
             field = value
-            value?.let { loadImage(it) }
+            loadImage(value)
         }
 
     var onModerationResult: ((Boolean) -> Unit)? = null
@@ -57,27 +58,73 @@ class ImageViewFilter @JvmOverloads constructor(
         }
     }
 
-    private fun loadImage(model: Any) {
+    private var currentImageModel: Any? = null
+
+    private fun loadImage(model: Any?) {
         moderationJob?.cancel()
 
+        if (model == null) {
+            currentImageModel = null
+            // Center the placeholder and make it smaller
+            scaleType = ScaleType.CENTER
+            setImageResource(R.drawable.place_holder)
+            return
+        }
+
+        val key = model.toString()
+        if (currentImageModel == model) return
+        currentImageModel = model
+
+        // Reset to normal for real images
+        scaleType = ScaleType.CENTER_CROP
+
+        // Check cache first
+        ModerationCacheManager.get(key)?.let { cachedState ->
+            cachedState.blurredBitmap?.let { blurred ->
+                setImageBitmap(blurred)
+                onModerationResult?.invoke(true)
+                return
+            }
+            cachedState.originalBitmap?.let { original ->
+                setImageBitmap(original)
+                onModerationResult?.invoke(false)
+                return
+            }
+        }
+
+        setImageResource(R.drawable.loading)
+
+        // Coil loading
         Coil.imageLoader(context).enqueue(
             ImageRequest.Builder(context)
                 .data(model)
-                .placeholder(R.drawable.place_holder)
-                .error(R.drawable.place_holder)
-                .target { drawable ->
-                    if (config.forceBlur) {
-                        applyBlur(drawable)
-                        onModerationResult?.invoke(true)
-                    } else if (config.enableModeration) {
-                        moderationJob = coroutineScope.launch(Dispatchers.Default) {
-                            processModeration(drawable)
+                .diskCachePolicy(CachePolicy.ENABLED)
+                .memoryCachePolicy(CachePolicy.ENABLED)
+                .crossfade(true)
+                .target(
+                    onStart = { placeholder ->
+                        scaleType = ScaleType.CENTER // small placeholder
+                        setImageDrawable(placeholder ?: context.getDrawable(R.drawable.loading))
+                    },
+                    onSuccess = { drawable ->
+                        scaleType = ScaleType.CENTER_CROP // real image
+                        if (config.forceBlur) {
+                            applyBlur(drawable)
+                            onModerationResult?.invoke(true)
+                        } else if (config.enableModeration) {
+                            moderationJob = coroutineScope.launch(Dispatchers.Default) {
+                                processModeration(drawable)
+                            }
+                        } else {
+                            setImageDrawable(drawable)
+                            onModerationResult?.invoke(false)
                         }
-                    } else {
-                        setImageDrawable(drawable)
-                        onModerationResult?.invoke(false)
+                    },
+                    onError = {
+                        scaleType = ScaleType.CENTER
+                        setImageResource(R.drawable.place_holder)
                     }
-                }
+                )
                 .build()
         )
     }

--- a/ImageHaramBlur/src/main/res/drawable/ic_loading.xml
+++ b/ImageHaramBlur/src/main/res/drawable/ic_loading.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector android:height="24dp" android:viewportHeight="72"
+    android:viewportWidth="72" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#cccccf"
+        android:pathData="M36.06,28.92L36.06,32.18"
+        android:strokeColor="#e7e7e7" android:strokeLineCap="round" android:strokeWidth="1"/>
+    <path android:fillColor="#c8c8cc"
+        android:pathData="M39.45,29.88L37.82,32.71"
+        android:strokeColor="#cacaca" android:strokeLineCap="round" android:strokeWidth="1"/>
+    <path android:fillColor="#bbbbbe"
+        android:pathData="M42.12,32.32L39.3,33.95"
+        android:strokeColor="#cdcdcd" android:strokeLineCap="round" android:strokeWidth="1"/>
+    <path android:fillColor="#b2b2b7"
+        android:pathData="M39.8,35.98L43.06,35.98"
+        android:strokeColor="#cbcbcb" android:strokeLineCap="round" android:strokeWidth="1"/>
+    <path android:fillColor="#d0d0d4"
+        android:pathData="M32.77,29.99L34.4,32.81"
+        android:strokeColor="#ededed" android:strokeLineCap="round" android:strokeWidth="1"/>
+    <path android:fillColor="#949497"
+        android:pathData="M30.1,32.42L32.92,34.05"
+        android:strokeColor="#525252" android:strokeLineCap="round" android:strokeWidth="1"/>
+    <path android:fillColor="#97979b"
+        android:pathData="M32.42,35.98L29.16,35.98"
+        android:strokeColor="#6e6e6e" android:strokeLineCap="round" android:strokeWidth="1"/>
+    <path android:fillColor="#a8a8ac"
+        android:pathData="M36.06,43.08L36.06,39.82"
+        android:strokeColor="#a0a0a0" android:strokeLineCap="round" android:strokeWidth="1"/>
+    <path android:fillColor="#cacaca"
+        android:pathData="M39.7,41.99L38.07,39.16"
+        android:strokeColor="#cacaca" android:strokeLineCap="round" android:strokeWidth="1"/>
+    <path android:fillColor="#b6b6ba"
+        android:pathData="M42.19,39.4L39.37,37.77"
+        android:strokeColor="#ccc" android:strokeLineCap="round" android:strokeWidth="1"/>
+    <path android:fillColor="#a1a1a5"
+        android:pathData="M32.46,41.98L34.09,39.16"
+        android:strokeColor="#909090" android:strokeLineCap="round" android:strokeWidth="1"/>
+    <path android:fillColor="#9d9da0"
+        android:pathData="M29.85,39.4L32.67,37.77"
+        android:strokeColor="#7a7a7a" android:strokeLineCap="round" android:strokeWidth="1"/>
+</vector>

--- a/ImageHaramBlur/src/main/res/drawable/loading.xml
+++ b/ImageHaramBlur/src/main/res/drawable/loading.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<animated-rotate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/ic_loading"
+    android:pivotX="50%"
+    android:pivotY="50%" />

--- a/app/src/main/java/com/karrar/movieapp/utilities/BindingAdapter.kt
+++ b/app/src/main/java/com/karrar/movieapp/utilities/BindingAdapter.kt
@@ -11,6 +11,7 @@ import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.PagerSnapHelper
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
+import com.ae.imageharamblur.ui.ImageViewFilter
 import com.google.android.material.chip.ChipGroup
 import com.google.android.material.textview.MaterialTextView
 import com.karrar.movieapp.R
@@ -225,6 +226,11 @@ fun bindMovieImage(image: ImageView, imageURL: String?) {
         }
     }
 }
+@BindingAdapter("imageUrl")
+fun ImageViewFilter.bindImageUrl(url: String?) {
+    this.imageModel = url
+}
+
 
 @BindingAdapter("posterImage")
 fun ImageView.setPosterImage(imageURL: String?) {

--- a/app/src/main/res/layout/fragment_actor_details.xml
+++ b/app/src/main/res/layout/fragment_actor_details.xml
@@ -137,7 +137,7 @@
                             app:isVisible="@{viewModel.actorDetailsUIState.success}"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent"
-                            app:posterImage="@{viewModel.actorDetailsUIState.imageUrl}"
+                            app:imageUrl="@{viewModel.actorDetailsUIState.imageUrl}"
                             app:shapeAppearanceOverlay="@style/CardCorners.Custom"
                             tools:src="@drawable/chris_evans" />
 

--- a/app/src/main/res/layout/grid_media_item.xml
+++ b/app/src/main/res/layout/grid_media_item.xml
@@ -18,7 +18,7 @@
         android:layout_margin="@dimen/spacing_simi_small"
         android:onClick="@{() -> listener.onMediaClick(item)}">
 
-        <com.google.android.material.imageview.ShapeableImageView
+        <com.ae.imageharamblur.ui.ImageViewFilter
             android:id="@+id/img_poster"
             android:layout_width="match_parent"
             android:layout_height="232dp"
@@ -27,9 +27,9 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:mediaPoster="@{item.mediaImage}"
-            app:shapeAppearanceOverlay="@style/CardCorners.Medium"
-            android:background="@drawable/image_error_palceholder" />
+            app:imageUrl="@{item.mediaImage}"
+            app:shapeAppearanceOverlay="@style/CardCorners.Medium" />
+
 
         <LinearLayout
             android:id="@+id/rating_container"

--- a/app/src/main/res/layout/item_actor_home.xml
+++ b/app/src/main/res/layout/item_actor_home.xml
@@ -33,7 +33,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:posterImage="@{item.imageUrl}"
+            app:imageUrl="@{item.imageUrl}"
             app:enableModeration="@{true}"
             app:detectFemales="@{true}"
             app:detectMales="@{false}" />

--- a/app/src/main/res/layout/item_airing_today.xml
+++ b/app/src/main/res/layout/item_airing_today.xml
@@ -33,7 +33,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:posterImage="@{item.imageUrl}"
+            app:imageUrl="@{item.imageUrl}"
             app:shapeAppearanceOverlay="@style/CardCorners.Medium" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_cast.xml
+++ b/app/src/main/res/layout/item_cast.xml
@@ -33,7 +33,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
-                app:posterImage="@{item.imageUrl}"
+                app:imageUrl="@{item.imageUrl}"
                 app:shapeAppearanceOverlay="@style/CastImage"
                 tools:srcCompat="@drawable/image" />
 

--- a/app/src/main/res/layout/item_category.xml
+++ b/app/src/main/res/layout/item_category.xml
@@ -18,7 +18,7 @@
         android:layout_margin="@dimen/spacing_simi_small"
         android:onClick="@{() -> listener.onClickCategory(item.mediaID)}">
 
-        <com.google.android.material.imageview.ShapeableImageView
+        <com.ae.imageharamblur.ui.ImageViewFilter
             android:id="@+id/img_poster"
             android:layout_width="match_parent"
             android:layout_height="232dp"
@@ -27,9 +27,9 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:mediaPoster="@{item.mediaImage}"
-            app:shapeAppearanceOverlay="@style/CardCorners.Medium"
-            tools:background="@drawable/image_error_palceholder" />
+            app:imageUrl="@{item.mediaImage}"
+            app:shapeAppearanceOverlay="@style/CardCorners.Medium" />
+
 
         <LinearLayout
             android:id="@+id/rating_container"

--- a/app/src/main/res/layout/item_media_card_explore.xml
+++ b/app/src/main/res/layout/item_media_card_explore.xml
@@ -42,14 +42,14 @@
                     app:cardUseCompatPadding="false"
                     app:shapeAppearanceOverlay="@style/PosterShapeStyle">
 
-                    <ImageView
+                    <com.ae.imageharamblur.ui.ImageViewFilter
                         android:id="@+id/img_poster"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:scaleType="centerCrop"
-                        android:background="@drawable/image_error_palceholder"
-                        app:mediaPoster="@{item.mediaImage}"
+                        app:imageUrl="@{item.mediaImage}"
                         android:contentDescription="@string/movie_poster" />
+
                 </com.google.android.material.card.MaterialCardView>
 
                 <LinearLayout

--- a/app/src/main/res/layout/item_movie.xml
+++ b/app/src/main/res/layout/item_movie.xml
@@ -31,11 +31,10 @@
             android:layout_marginBottom="@dimen/radius_cineVerse_s"
             android:onClick="@{()->listener.onClickMovie(item.id)}"
             android:scaleType="centerCrop"
-
             app:layout_constraintDimensionRatio="136:182"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:posterImage="@{item.imageUrl}"
+            app:imageUrl="@{item.imageUrl}"
             app:shapeAppearanceOverlay="@style/CardCorners.Medium"
             tools:background="@color/brand_color_primary"
             tools:ignore="MissingConstraints" />

--- a/app/src/main/res/layout/item_movie_detail_header.xml
+++ b/app/src/main/res/layout/item_movie_detail_header.xml
@@ -192,7 +192,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:posterImage="@{item.image}"
+            app:imageUrl="@{item.image}"
             app:shapeAppearanceOverlay="@style/CardCorners.Medium" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_recently_viewed.xml
+++ b/app/src/main/res/layout/item_recently_viewed.xml
@@ -25,11 +25,10 @@
             android:layout_marginBottom="@dimen/radius_cineVerse_s"
             android:onClick="@{()->listener.onClickMovie(item)}"
             android:scaleType="centerCrop"
-
             app:layout_constraintDimensionRatio="136:182"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:posterImage="@{item.posterPath}"
+            app:imageUrl="@{item.posterPath}"
             app:shapeAppearanceOverlay="@style/CardCorners.Medium"
             tools:background="@color/brand_color_primary"
             tools:ignore="MissingConstraints" />

--- a/app/src/main/res/layout/item_similar_series.xml
+++ b/app/src/main/res/layout/item_similar_series.xml
@@ -31,7 +31,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:posterImage="@{item.imageUrl}"
+            app:imageUrl="@{item.imageUrl}"
             app:shapeAppearanceOverlay="@style/CardCorners.Medium"
             tools:background="@color/brand_color_primary" />
 

--- a/app/src/main/res/layout/item_tv_show_details_header.xml
+++ b/app/src/main/res/layout/item_tv_show_details_header.xml
@@ -178,7 +178,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:posterImage="@{item.tvShowImage}" />
+            app:imageUrl="@{item.tvShowImage}" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_tvshow.xml
+++ b/app/src/main/res/layout/item_tvshow.xml
@@ -30,11 +30,10 @@
             android:layout_marginBottom="@dimen/radius_cineVerse_s"
             android:onClick="@{()->listener.onClickTVShow(item.id)}"
             android:scaleType="centerCrop"
-
             app:layout_constraintDimensionRatio="136:182"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:posterImage="@{item.imageUrl}"
+            app:imageUrl="@{item.imageUrl}"
             app:shapeAppearanceOverlay="@style/CardCorners.Medium"
             tools:background="@color/brand_color_primary"
             tools:ignore="MissingConstraints" />

--- a/app/src/main/res/layout/list_media_item.xml
+++ b/app/src/main/res/layout/list_media_item.xml
@@ -43,13 +43,12 @@
                     app:cardUseCompatPadding="false"
                     app:shapeAppearanceOverlay="@style/PosterShapeStyle">
 
-                    <ImageView
+                    <com.ae.imageharamblur.ui.ImageViewFilter
                         android:id="@+id/img_poster"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:scaleType="centerCrop"
-                        android:background="@drawable/image_error_palceholder"
-                        app:mediaPoster="@{item.mediaImage}"
+                        app:imageUrl="@{item.mediaImage}"
                         android:contentDescription="@string/movie_poster" />
                 </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/movie_detail_item.xml
+++ b/app/src/main/res/layout/movie_detail_item.xml
@@ -30,13 +30,12 @@
             android:layout_height="@dimen/media_card_height"
             android:scaleType="centerCrop"
             android:layout_marginBottom="@dimen/radius_cineVerse_s"
-
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintDimensionRatio="136:182"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:posterImage="@{item.imageUrl}"
+            app:imageUrl="@{item.imageUrl}"
             app:shapeAppearanceOverlay="@style/CardCorners.Medium"
             tools:background="@color/brand_color_primary" />
 

--- a/app/src/main/res/layout/three_image_gallery.xml
+++ b/app/src/main/res/layout/three_image_gallery.xml
@@ -36,7 +36,7 @@
             android:layout_width="0dp"
             android:layout_height="280dp"
             android:layout_weight="1"
-            app:posterImage="@{secondImageUrl}"
+            app:imageUrl="@{secondImageUrl}"
             android:layout_marginStart="6dp"
             tools:background="@color/yellow" />
 


### PR DESCRIPTION
- Implemented placeholder support – ensured a placeholder image is displayed when the image URL is null or loading fails.

- Added conditional scaling for placeholders – scaled placeholder images to be smaller and centered, while keeping real images centerCrop.

- Integrated manual cache check – used ModerationCacheManager to avoid reloading images unnecessarily when they were previously processed.

- Maintained moderation workflow – ensured that image moderation (blurring sensitive content) continues to work seamlessly with the new placeholder logic.

- Improved RecyclerView experience – prevented flickering and unnecessary reloads when scrolling back to previously displayed images. 
<img width="1080" height="2220" alt="image" src="https://github.com/user-attachments/assets/18d73b9d-9846-47e4-8699-4dd83be258c2" />
